### PR TITLE
feat!: add HasValue support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons</groupId>
     <artifactId>markdown-editor-addon</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Markdown Editor Add-on</name>
     <description>Markdown Editor for Vaadin Flow</description>
     <url>https://www.flowingcode.com/en/open-source/</url>

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
@@ -65,6 +65,12 @@ public class MarkdownEditor
     getEditor().addContentChangeListener(newValue -> setModelValue(newValue, true));
   }
 
+
+  @Override
+  protected MarkdownEditorComponent initContent() {
+    return new MarkdownEditorComponent();
+  }
+
   /**
    * Returns the editor component.
    *

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
@@ -51,18 +51,9 @@ public class MarkdownEditor
    * @param initialValue the initial content for the Markdown editor
    */
   public MarkdownEditor(String initialValue) {
-    this(new MarkdownEditorComponent());
-    getEditor().setContent(initialValue);
-  }
-
-  /**
-   * Constructor with a custom editor component.
-   *
-   * @param editor the editor component.
-   */
-  protected MarkdownEditor(MarkdownEditorComponent editor) {
     super("");
     getEditor().addContentChangeListener(newValue -> setModelValue(newValue, true));
+    getEditor().setContent(initialValue);
   }
 
 

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
@@ -110,10 +110,10 @@ public class MarkdownEditor
   /**
    * Sets the maximum character count for the Markdown editor.
    *
-   * @param maxlength the maximum character count
+   * @param maxLength the maximum character count
    */
-  public void setMaxLength(int maxlength) {
-    getEditor().setMaxLength(maxlength);
+  public void setMaxLength(int maxLength) {
+    getEditor().setMaxLength(maxLength);
   }
 
   /**

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
@@ -23,17 +23,11 @@ package com.flowingcode.vaadin.addons.markdown;
 import com.flowingcode.vaadin.addons.markdown.BaseMarkdownComponent.DataColorMode;
 import com.vaadin.flow.component.AbstractCompositeField;
 import com.vaadin.flow.component.HasSize;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**
  * Markdown component that allows editing the contents.
  */
 @SuppressWarnings("serial")
-@NpmPackage(value = "rehype-sanitize", version = "6.0.0")
-@JsModule("./markdown-editor.tsx")
-@Tag("markdown-editor")
 public class MarkdownEditor
     extends AbstractCompositeField<MarkdownEditorComponent, MarkdownEditor, String>
     implements HasSize {

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorComponent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorComponent.java
@@ -79,10 +79,10 @@ class MarkdownEditorComponent extends BaseMarkdownComponent {
   /**
    * Sets the maximum character count for the Markdown editor.
    *
-   * @param maxlength the maximum character count
+   * @param maxLength the maximum character count
    */
-  public void setMaxLength(int maxlength) {
-    setState("maxLength", maxlength);
+  public void setMaxLength(int maxLength) {
+    setState("maxLength", maxLength);
   }
 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorComponent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorComponent.java
@@ -20,58 +20,33 @@
 
 package com.flowingcode.vaadin.addons.markdown;
 
-import com.flowingcode.vaadin.addons.markdown.BaseMarkdownComponent.DataColorMode;
-import com.vaadin.flow.component.AbstractCompositeField;
-import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 
 /**
- * Markdown component that allows editing the contents.
+ * React adapter for markdown-editor.
  */
 @SuppressWarnings("serial")
 @NpmPackage(value = "rehype-sanitize", version = "6.0.0")
 @JsModule("./markdown-editor.tsx")
 @Tag("markdown-editor")
-public class MarkdownEditor
-    extends AbstractCompositeField<MarkdownEditorComponent, MarkdownEditor, String>
-    implements HasSize {
+public class MarkdownEditorComponent extends BaseMarkdownComponent {
 
   /**
    * Constructor with empty content.
    */
-  public MarkdownEditor() {
-    this("");
-  }
-
-  /**
-   * Constructor with initial value.
-   *
-   * @param initialValue the initial content for the Markdown editor
-   */
-  public MarkdownEditor(String initialValue) {
-    this(new MarkdownEditorComponent());
-    getEditor().setContent(initialValue);
-  }
-
-  /**
-   * Constructor with a custom editor component.
-   *
-   * @param editor the editor component.
-   */
-  protected MarkdownEditor(MarkdownEditorComponent editor) {
+  public MarkdownEditorComponent() {
     super("");
-    getEditor().addContentChangeListener(newValue -> setModelValue(newValue, true));
   }
 
   /**
-   * Returns the editor component.
+   * Constructor with default content.
    *
-   * @return the editor component
+   * @param content default content for the Markdown editor
    */
-  protected final MarkdownEditorComponent getEditor() {
-    return getContent();
+  public MarkdownEditorComponent(String content) {
+    super(content);
   }
 
   /**
@@ -80,7 +55,7 @@ public class MarkdownEditor
    * @return the placeholder text
    */
   public String getPlaceholder() {
-    return getEditor().getPlaceholder();
+    return getState("placeholder", String.class);
   }
 
   /**
@@ -89,7 +64,7 @@ public class MarkdownEditor
    * @param placeholder the placeholder text
    */
   public void setPlaceholder(String placeholder) {
-    getEditor().setPlaceholder(placeholder);
+    setState("placeholder", placeholder);
   }
 
   /**
@@ -98,7 +73,7 @@ public class MarkdownEditor
    * @return the configured maximum character count
    */
   public int getMaxLength() {
-    return getEditor().getMaxLength();
+    return getState("maxLength", Integer.class);
   }
 
   /**
@@ -107,21 +82,7 @@ public class MarkdownEditor
    * @param maxlength the maximum character count
    */
   public void setMaxLength(int maxlength) {
-    getEditor().setMaxLength(maxlength);
-  }
-
-  /**
-   * Sets the color mode of the Markdown component.
-   *
-   * @param mode the color mode of the component
-   */
-  public void setDataColorMode(DataColorMode mode) {
-    getEditor().setDataColorMode(mode);
-  }
-
-  @Override
-  protected void setPresentationValue(String newPresentationValue) {
-    getEditor().setContent(newPresentationValue);
+    setState("maxLength", maxlength);
   }
 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorComponent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorComponent.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "rehype-sanitize", version = "6.0.0")
 @JsModule("./markdown-editor.tsx")
 @Tag("markdown-editor")
-public class MarkdownEditorComponent extends BaseMarkdownComponent {
+class MarkdownEditorComponent extends BaseMarkdownComponent {
 
   /**
    * Constructor with empty content.

--- a/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownBinderDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownBinderDemo.java
@@ -1,0 +1,67 @@
+/*-
+ * #%L
+ * Markdown Editor Add-on
+ * %%
+ * Copyright (C) 2024-2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.markdown;
+
+import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@DemoSource
+@PageTitle("Markdown Editor with Binder")
+@SuppressWarnings("serial")
+@Route(value = "markdown-editor/binder", layout = MarkdownDemoView.class)
+public class MarkdownBinderDemo extends VerticalLayout {
+
+  public MarkdownBinderDemo() {
+    setSizeFull();
+    Binder<Bean> binder = new Binder<>();
+    MarkdownEditor mde = new MarkdownEditor();
+    mde.setSizeFull();
+    mde.setPlaceholder("Enter Markdown here");
+    mde.setMaxLength(500);
+
+    binder.forField(mde).bind(Bean::getText, Bean::setText);
+    binder.setBean(new Bean());
+
+    Button getContentButton =
+        new Button("Show content", ev -> Notification.show(binder.getBean().getText()));
+    Button setSampleContent =
+        new Button("Set sample content", ev -> mde.setValue("**Hello** _world_"));
+    add(mde, new HorizontalLayout(getContentButton, setSampleContent));
+  }
+
+  private static class Bean {
+    String text;
+
+    public String getText() {
+      return text;
+    }
+
+    public void setText(String text) {
+      this.text = text;
+    }
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownDemoView.java
@@ -34,6 +34,7 @@ public class MarkdownDemoView extends TabbedDemo {
   public MarkdownDemoView() {
     addDemo(MarkdownViewerDemo.class);
     addDemo(MarkdownEditorDemo.class);
+    addDemo(MarkdownBinderDemo.class);
     setSizeFull();
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorDemo.java
@@ -2,14 +2,14 @@
  * #%L
  * Markdown Editor Add-on
  * %%
- * Copyright (C) 2024 Flowing Code
+ * Copyright (C) 2024-2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,9 +61,9 @@ public class MarkdownEditorDemo extends VerticalLayout {
           break;
       }
     });
-    Button getContentButton = new Button("Show content",ev->Notification.show(mde.getContent()));
+    Button getContentButton = new Button("Show content",ev->Notification.show(mde.getValue()));
     Button setSampleContent = new Button("Set sample content",ev->{
-      mde.setContent("""
+      mde.setValue("""
 # Markdown Editor Demo
 
 ## This is a heading


### PR DESCRIPTION
I had to add an intermediate class since there is no "CustomReactFieldAdapter". I tried to use `CustomField` instead of `AbstractCompositeField` but it didn't handle state synchronization properly. (Still, it’s a breaking change because I had to change the class hierarchy.)

Close #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Markdown Editor add-on version to 2.0.0-SNAPSHOT.

- **New Features**
	- Introduced enhanced content management with a more intuitive value API and customizable input settings.
	- Added support for adjusting color modes to tailor the editing experience.
	- Added a new demo showcasing data binding integration with the Markdown Editor.

- **Refactor**
	- Streamlined the editor’s core structure to deliver a more consistent and reliable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->