### PR TITLE
Apply application's theme to MarkdownEditor component

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditor.java
@@ -20,7 +20,6 @@
 
 package com.flowingcode.vaadin.addons.markdown;
 
-import com.flowingcode.vaadin.addons.markdown.BaseMarkdownComponent.DataColorMode;
 import com.vaadin.flow.component.AbstractCompositeField;
 import com.vaadin.flow.component.HasSize;
 
@@ -99,15 +98,6 @@ public class MarkdownEditor
    */
   public void setMaxLength(int maxLength) {
     getEditor().setMaxLength(maxLength);
-  }
-
-  /**
-   * Sets the color mode of the Markdown component.
-   *
-   * @param mode the color mode of the component
-   */
-  public void setDataColorMode(DataColorMode mode) {
-    getEditor().setDataColorMode(mode);
   }
 
   @Override

--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownViewer.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/MarkdownViewer.java
@@ -22,8 +22,6 @@ package com.flowingcode.vaadin.addons.markdown;
 
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
-import com.vaadin.flow.component.react.ReactAdapterComponent;
 
 /**
  * Component for displaying Markdown text

--- a/src/main/resources/META-INF/resources/frontend/connector.js
+++ b/src/main/resources/META-INF/resources/frontend/connector.js
@@ -28,13 +28,14 @@
 
 			markDownEditor.$connector = {};
 
-            const supportedTheme = theme => ['light', 'dark'].includes(theme);
-            
+			const supportedTheme = theme => ['light', 'dark'].includes(theme);
+
 			const setDataColorMode = theme => {
 				if (supportedTheme(theme)) {
 					markDownEditor.setAttribute('data-color-mode', theme);
 				} else {
-					markDownEditor.removeAttribute('data-color-mode');
+					// force light theme which is Vaadin's default theme
+					markDownEditor.setAttribute('data-color-mode', 'light');
 				}
 			};
 
@@ -43,30 +44,32 @@
 			if (supportedTheme(mainTheme)) {
 				setDataColorMode(mainTheme);
 			} else {
-				// Listen for theme changes in body element otherwise
-
-				// options for the observer (which mutations to observe)
-				const config = { attributes: true };
-
-				// callback function to execute when mutations are observed
-				const callback = (mutationList, observer) => {
-					for (const mutation of mutationList) {
-						if (mutation.type === 'attributes' && mutation.attributeName === 'theme') {
-                            const themeName = mutation.target.getAttribute(mutation.attributeName);
-                            setDataColorMode(themeName);
-						}
-					}
-				};
-
-				// create an observer instance linked to the callback function
-				markDownEditor.$connector.themeChangeObserver = new MutationObserver(callback);
-
-				// start observing html tag for configured mutations
-				markDownEditor.$connector.themeChangeObserver.observe(document.documentElement, config);
-
-				// start observing body tag for configured mutations
-				markDownEditor.$connector.themeChangeObserver.observe(document.body, config);
+				// set light theme by default
+				markDownEditor.setAttribute('data-color-mode', 'light');
 			}
+
+			// options for the observer (which mutations to observe)
+			const config = { attributes: true };
+
+			// callback function to execute when mutations are observed
+			const callback = (mutationList, observer) => {
+				for (const mutation of mutationList) {
+					if (mutation.type === 'attributes' && mutation.attributeName === 'theme') {
+						const themeName = mutation.target.getAttribute(mutation.attributeName);
+						console.log("theme", themeName);
+						setDataColorMode(themeName);
+					}
+				}
+			};
+
+			// create an observer instance linked to the callback function
+			markDownEditor.$connector.themeChangeObserver = new MutationObserver(callback);
+
+			// observe html tag for configured mutations
+			markDownEditor.$connector.themeChangeObserver.observe(document.documentElement, config);
+
+			// observe body tag for configured mutations
+			markDownEditor.$connector.themeChangeObserver.observe(document.body, config);
 		},
 		unobserveThemeChange: markDownEditor => {
 			// stop observing the target node for configured mutations

--- a/src/main/resources/META-INF/resources/frontend/connector.js
+++ b/src/main/resources/META-INF/resources/frontend/connector.js
@@ -2,7 +2,7 @@
  * #%L
  * Markdown Editor Add-on
  * %%
- * Copyright (C) 2024 Flowing Code
+ * Copyright (C) 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/resources/frontend/connector.js
+++ b/src/main/resources/META-INF/resources/frontend/connector.js
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * Markdown Editor Add-on
+ * %%
+ * Copyright (C) 2024 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+(function() {
+
+	window.Vaadin.Flow.fcMarkdownEditorConnector = {
+		observeThemeChange: markDownEditor => {
+			// Check whether the connector was already initialized for markDownEditor
+			if (markDownEditor.$connector) {
+				return;
+			}
+
+			markDownEditor.$connector = {};
+
+            const supportedTheme = theme => ['light', 'dark'].includes(theme);
+            
+			const setDataColorMode = theme => {
+				if (supportedTheme(theme)) {
+					markDownEditor.setAttribute('data-color-mode', theme);
+				} else {
+					markDownEditor.removeAttribute('data-color-mode');
+				}
+			};
+
+			// Get theme from html element when using Vaadin's @Theme annotation
+			const mainTheme = document.documentElement.getAttribute('theme');
+			if (supportedTheme(mainTheme)) {
+				setDataColorMode(mainTheme);
+			} else {
+				// Listen for theme changes in body element otherwise
+
+				// options for the observer (which mutations to observe)
+				const config = { attributes: true };
+
+				// callback function to execute when mutations are observed
+				const callback = (mutationList, observer) => {
+					for (const mutation of mutationList) {
+						if (mutation.type === 'attributes' && mutation.attributeName === 'theme') {
+                            const themeName = mutation.target.getAttribute(mutation.attributeName);
+                            setDataColorMode(themeName);
+						}
+					}
+				};
+
+				// create an observer instance linked to the callback function
+				markDownEditor.$connector.themeChangeObserver = new MutationObserver(callback);
+
+				// start observing html tag for configured mutations
+				markDownEditor.$connector.themeChangeObserver.observe(document.documentElement, config);
+
+				// start observing body tag for configured mutations
+				markDownEditor.$connector.themeChangeObserver.observe(document.body, config);
+			}
+		},
+		unobserveThemeChange: markDownEditor => {
+			// stop observing the target node for configured mutations
+			if (markDownEditor.$connector.themeChangeObserver) {
+				markDownEditor.$connector.themeChangeObserver.disconnect();
+				markDownEditor.$connector.themeChangeObserver = null;
+			}
+		}
+	}
+})();

--- a/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownEditorDemo.java
@@ -20,7 +20,7 @@
 package com.flowingcode.vaadin.addons.markdown;
 
 import com.flowingcode.vaadin.addons.demo.DemoSource;
-import com.flowingcode.vaadin.addons.markdown.BaseMarkdownComponent.DataColorMode;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.notification.Notification;
@@ -28,6 +28,8 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.lumo.Lumo;
+import java.util.List;
 
 @DemoSource
 @PageTitle("Markdown Editor Demo")
@@ -41,26 +43,6 @@ public class MarkdownEditorDemo extends VerticalLayout {
     mde.setSizeFull();
     mde.setPlaceholder("Enter Markdown here");
     mde.setMaxLength(500);
-    mde.setDataColorMode(DataColorMode.LIGTH);
-    ComboBox<String> cb = new ComboBox<String>();
-    cb.setItems("Dark","Light","Automatic");
-    cb.setLabel("Color mode");
-    cb.setValue("Light");
-    cb.addValueChangeListener(ev->{
-      switch(ev.getValue()) {
-        case "Dark":
-          mde.setDataColorMode(DataColorMode.DARK);
-          break;
-        case "Light":
-          mde.setDataColorMode(DataColorMode.LIGHT);
-          break;
-        case "Automatic":
-          mde.setDataColorMode(DataColorMode.AUTO);
-          break;
-        default:
-          break;
-      }
-    });
     Button getContentButton = new Button("Show content",ev->Notification.show(mde.getValue()));
     Button setSampleContent = new Button("Set sample content",ev->{
       mde.setValue("""
@@ -90,6 +72,6 @@ _This is italic text_
 ~~This is strikethrough text~~
       """);
     });
-    add(mde,cb,new HorizontalLayout(getContentButton,setSampleContent));
+    add(mde,new HorizontalLayout(getContentButton,setSampleContent));
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownViewerDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/markdown/MarkdownViewerDemo.java
@@ -20,8 +20,6 @@
 package com.flowingcode.vaadin.addons.markdown;
 
 import com.flowingcode.vaadin.addons.demo.DemoSource;
-import com.flowingcode.vaadin.addons.markdown.BaseMarkdownComponent.DataColorMode;
-import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -36,7 +34,6 @@ public class MarkdownViewerDemo extends VerticalLayout {
     setSizeFull();
     MarkdownViewer mdv = new MarkdownViewer();
     mdv.setSizeFull();
-    mdv.setDataColorMode(DataColorMode.LIGTH);
     mdv.setContent("""
 
 # h1 Heading
@@ -202,25 +199,6 @@ Duplicated footnote reference[^second].
 [^second]: Footnote text.
             
             """);
-    ComboBox<String> cb = new ComboBox<String>();
-    cb.setItems("Dark","Light","Automatic");
-    cb.setLabel("Color mode");
-    cb.setValue("Light");
-    cb.addValueChangeListener(ev->{
-      switch(ev.getValue()) {
-        case "Dark":
-          mdv.setDataColorMode(DataColorMode.DARK);
-          break;
-        case "Light":
-          mdv.setDataColorMode(DataColorMode.LIGHT);
-          break;
-        case "Automatic":
-          mdv.setDataColorMode(DataColorMode.AUTO);
-          break;
-        default:
-          break;
-      }
-    });
-    add(mdv,cb);
+    add(mdv);
   }
 }


### PR DESCRIPTION
Close #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Markdown editor and viewer now automatically adapt their appearance to match the application's theme (light or dark mode) without manual configuration.

- **Bug Fixes**
  - Improved synchronization of the editor's color scheme with theme changes in the hosting application.

- **Chores**
  - Removed manual color mode selection controls from demo interfaces for a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->