### PR TITLE
docs: fix swapped Javadocs for getContent/setContent

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/markdown/BaseMarkdownComponent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/markdown/BaseMarkdownComponent.java
@@ -53,7 +53,7 @@ public class BaseMarkdownComponent extends ReactAdapterComponent implements HasS
   }
   
   /**
-   * Sets the content of the Markdown component.
+   * Gets the content of the Markdown component.
    * 
    * @return the content of the Markdown component
    */
@@ -62,9 +62,9 @@ public class BaseMarkdownComponent extends ReactAdapterComponent implements HasS
   }
 
   /**
-   * Gets the content of the Markdown component.
+   * Sets the content of the Markdown component.
    * 
-   * @param content retrieved from the state of the component
+   * @param content the content to be used in the Markdown component
    */
   public void setContent(String content) {
     this.content = content;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated and corrected API documentation for the Markdown component’s content getter and setter, aligning method descriptions with actual behavior and clarifying the parameter’s purpose.
  - Improves readability and developer guidance when using the component’s content API.
  - Enhances consistency across documentation and reduces confusion.
  - No functional changes; runtime behavior and public API remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->