### PR TITLE
fix: safely disconnect themeChangeObserver with optional chaining

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/fcMarkdownEditorConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/fcMarkdownEditorConnector.js
@@ -73,7 +73,7 @@
 		},
 		unobserveThemeChange: markDownEditor => {
 			// stop observing the target node for configured mutations
-			if (markDownEditor.$connector.themeChangeObserver) {
+			if (markDownEditor?.$connector?.themeChangeObserver) {
 				markDownEditor.$connector.themeChangeObserver.disconnect();
 				markDownEditor.$connector.themeChangeObserver = null;
 			}


### PR DESCRIPTION
Close #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare runtime errors in the Markdown editor by making the theme observer cleanup more robust, improving stability during theme changes and when the editor is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->