### PR TITLE
ci: add jakarta.servlet-api to v25 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,6 +517,12 @@
                     <artifactId>vaadin-dev</artifactId>
                     <optional>true</optional>
                 </dependency>
+                <dependency>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                    <version>6.1.0</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
         


### PR DESCRIPTION
Close #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test dependencies for the v25 Maven profile to support the latest Jakarta Servlet API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->